### PR TITLE
feat: if rule.name contains spaces, don't treat as camel case

### DIFF
--- a/src/main/java/com/fortify/ssc/parser/sarif/parser/VulnerabilitiesProducer.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/parser/VulnerabilitiesProducer.java
@@ -169,7 +169,11 @@ public final class VulnerabilitiesProducer {
 				category = result.resolveMessage(rule.getShortDescription(), runData);
 			}
 			if ( StringUtils.isBlank(category) && StringUtils.isNotBlank(rule.getName()) ) {
-				category = StringUtils.capitalize(StringUtils.join(StringUtils.splitByCharacterTypeCamelCase(rule.getName()), StringUtils.SPACE));
+				if ( rule.getName().contains(StringUtils.SPACE)) {
+					category = rule.getName();
+				}else {
+					category = StringUtils.capitalize(StringUtils.join(StringUtils.splitByCharacterTypeCamelCase(rule.getName()), StringUtils.SPACE));
+				}
 			}
 			if ( StringUtils.isBlank(category) ) {
 				category = getStringProperty(getRuleProperties(rule), "Type", null);


### PR DESCRIPTION
Some SARIF files have rule names that are normal text (not camel case). Expanding regular text as if it was camel case results in very much less than ideal text.