### PR TITLE
feat: handle SARIF kind

### DIFF
--- a/src/main/java/com/fortify/ssc/parser/sarif/domain/Kind.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/domain/Kind.java
@@ -24,6 +24,78 @@
  ******************************************************************************/
 package com.fortify.ssc.parser.sarif.domain;
 
+/**
+ * A <code>result</code> object MAY contain a property named kind whose value is one of a fixed set of strings that specify the nature of the result.
+ * @see <a href="https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317647">Static Analysis Results Interchange Format (SARIF) Version 2.1.0: 3.27.9 kind property</a>
+ */
 public enum Kind {
-	pass, open, informational, notApplicable, review, fail
+	/**
+	 * The rule specified by <code>ruleId</code> (§3.27.5), <code>ruleIndex</code> (§3.27.6), and/or <code>rule</code> (§3.27.7) was evaluated, and no problem was found.
+	 */
+	pass,
+
+	/**
+	 * The specified rule was evaluated, and the tool concluded that there was insufficient information to decide whether a problem exists.
+	 *<p>
+	 * This value is used by proof-based tools. Sometimes such a tool can prove that there is no violation (<code>kind = "pass"</code>), sometimes it can prove that there is a violation (<code>kind = "fail"</code>), and sometimes it does not detect a violation but is unable to prove that there is none (kind = "open"). In such a tool, a kind value of "open" might be an indication that the user should add additional assertions to enable the tool to determine if there is a violation.
+	 */
+	open,
+
+	/**
+	 * The specified rule was evaluated and produced a purely informational result that does not indicate the presence of a problem.
+	 */
+	informational,
+
+	/**
+	 * The rule specified by <code>ruleId</code> was not evaluated, because it does not apply to the analysis target.
+	 *
+	 * EXAMPLE: In this example, a binary checker has a rule that applies to 32-bit binaries only. It produces a "notApplicable" result if it is run on a 64-bit binary. It also has a rule that checks the compiler version and produces an informational result:
+<pre>{@code
+"results": [
+  {
+    "ruleId": "ABC0001",
+    "kind": "notApplicable",
+    "message": {
+      "text": "\"MyTool64.exe\" was not evaluated for rule ABC0001
+               because it is not a 32-bit binary."
+    },
+    "locations": [
+      {
+        "physicalLocation": {
+          "uri": "file://C:/bin/MyTool64.exe"
+        }
+      }
+    ]
+  },
+  {
+    "ruleId": "ABC0002",
+    "kind": "informational",
+    "message": {
+      "text": "\"MyTool64.exe\" was compiled with Example Corporation
+               Compiler version 10.2.2."
+    },
+    "locations": [
+      {
+        "physicalLocation": {
+          "uri": "file://C:/bin/MyTool64.exe"
+        }
+      }
+    ]
+  }
+]
+}</pre>
+	 */
+	notApplicable,
+
+	/**
+	 * The result requires review by a human user to decide if it represents a problem.
+	 * <p>
+	 * This value is used by tools that are unable to check for certain conditions, but that wish to bring to the user’s attention the possibility that there might be a problem. For example, an accessibility checker might produce a result with the message "Do not use color alone to highlight important information," with <code>kind = "review"</code>. A user might address this issue by visually inspecting the UI.
+	 */
+	review,
+
+	/**
+	 * The result represents a problem whose severity is specified by the <code>level</code> property (§3.27.10).
+	 */
+	fail
 }

--- a/src/main/java/com/fortify/ssc/parser/sarif/parser/VulnerabilitiesProducer.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/parser/VulnerabilitiesProducer.java
@@ -12,6 +12,7 @@ import com.fortify.plugin.api.BasicVulnerabilityBuilder.Priority;
 import com.fortify.plugin.api.StaticVulnerabilityBuilder;
 import com.fortify.plugin.api.VulnerabilityHandler;
 import com.fortify.ssc.parser.sarif.CustomVulnAttribute;
+import com.fortify.ssc.parser.sarif.domain.Kind;
 import com.fortify.ssc.parser.sarif.domain.ReportingDescriptor;
 import com.fortify.ssc.parser.sarif.domain.Result;
 import com.fortify.ssc.parser.sarif.domain.RunData;
@@ -40,6 +41,22 @@ public final class VulnerabilitiesProducer {
 	 */
 	@SuppressWarnings("deprecation") // SSC JavaDoc states that severity is mandatory, but method is deprecated
 	public final void produceVulnerability(RunData runData, Result result) {
+		Kind kind = result.getKind();
+		if ( kind == null ) {
+			// SARIF specification says that if kind is not specified, then the default value of fail is to be used
+			kind = Kind.fail;
+		}
+		switch(kind) {
+			case review:
+			case open:
+			case fail:
+				break;
+			case informational:
+			case notApplicable:
+			case pass:
+				// results with these kind values are not vulnerabilities.
+				return;
+		}
 		Priority priority = getPriority(runData, result);
 		if ( priority != null ) {
 			StaticVulnerabilityBuilder vb = vulnerabilityHandler.startStaticVulnerability(getInstanceId(runData, result));

--- a/src/test/java/com/fortify/ssc/parser/sarif/SARIFParserPluginTest.java
+++ b/src/test/java/com/fortify/ssc/parser/sarif/SARIFParserPluginTest.java
@@ -59,8 +59,8 @@ class SARIFParserPluginTest {
 			"spec-minimal-without-source.sarif",
 			"spec-minimal-with-source.sarif",
 			"spec-comprehensive.sarif",
-			"gitlab.com_microsoft_sarif-sdk_blob_master_src_Samples_Sarif.WorkItems.Sample_SampleTestFiles_Current.sarif",
-			"gitlab.com_microsoft_sarif-sdk_blob_master_src_Test.FunctionalTests.Sarif_v2_ConverterTestData_ContrastSecurity_WebGoat.xml.sarif"
+			"github.com_microsoft_sarif-sdk_blob_master_src_Samples_Sarif.WorkItems.Sample_SampleTestFiles_Current.sarif",
+			"github.com_microsoft_sarif-sdk_blob_master_src_Test.FunctionalTests.Sarif_v2_ConverterTestData_ContrastSecurity_WebGoat.xml.sarif"
 	};
 	
 	private final ScanData getScanData(String fileName) {


### PR DESCRIPTION
kind is how SARIF indicates if a record was evaluated, not applicable, informational, requires manual review, or is a problem.

The mapping for value of kind and how it is handled by this plugin is:
* pass does not record the vulnerability in fortify
* open behaves the same as fail
* informational does not record the vulnerability in fortify
* notApplicable does not record the vulnerability in fortify
* review behaves the same as fail
* fail (default is kind is no specified) records the vulnerability in fortify

See: https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317647

See: https://github.com/fortify/fortify-ssc-parser-sarif/issues/18
