### PR TITLE
fix: correct test data file names

### DIFF
--- a/src/test/java/com/fortify/ssc/parser/sarif/SARIFParserPluginTest.java
+++ b/src/test/java/com/fortify/ssc/parser/sarif/SARIFParserPluginTest.java
@@ -59,8 +59,8 @@ class SARIFParserPluginTest {
 			"spec-minimal-without-source.sarif",
 			"spec-minimal-with-source.sarif",
 			"spec-comprehensive.sarif",
-			"gitlab.com_microsoft_sarif-sdk_blob_master_src_Samples_Sarif.WorkItems.Sample_SampleTestFiles_Current.sarif",
-			"gitlab.com_microsoft_sarif-sdk_blob_master_src_Test.FunctionalTests.Sarif_v2_ConverterTestData_ContrastSecurity_WebGoat.xml.sarif"
+			"github.com_microsoft_sarif-sdk_blob_master_src_Samples_Sarif.WorkItems.Sample_SampleTestFiles_Current.sarif",
+			"github.com_microsoft_sarif-sdk_blob_master_src_Test.FunctionalTests.Sarif_v2_ConverterTestData_ContrastSecurity_WebGoat.xml.sarif"
 	};
 	
 	private final ScanData getScanData(String fileName) {


### PR DESCRIPTION
The filename provided in SARIFParserPluginTest were incorrect.

This mistake was introduced in commit 6b167aea

See: https://github.com/fortify/fortify-ssc-parser-sarif/pull/17