### PR TITLE
feat: Display SARIF tags

### DIFF
--- a/src/main/java/com/fortify/ssc/parser/sarif/CustomVulnAttribute.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/CustomVulnAttribute.java
@@ -39,6 +39,7 @@ public enum CustomVulnAttribute implements com.fortify.plugin.spi.VulnerabilityA
 	categoryAndSubCategory(AttrType.STRING),
 	help(AttrType.LONG_STRING),
 	helpUri(AttrType.STRING),
+	tags(AttrType.LONG_STRING),
     ;
 
     private final AttrType attributeType;

--- a/src/main/resources/plugin.xml
+++ b/src/main/resources/plugin.xml
@@ -5,7 +5,7 @@
     <plugin-info>
         <name>SARIF parser plugin</name>
         <version><!--VERSION-->0.0<!--/VERSION--></version>
-        <data-version>2</data-version>
+        <data-version>3</data-version>
         <vendor name="Micro Focus" url="https://www.microfocus.com"/>
         <description>SARIF parser plugin</description>
         <resources>

--- a/src/main/resources/resources/sarif_en.properties
+++ b/src/main/resources/resources/sarif_en.properties
@@ -22,5 +22,6 @@ audited=Audited
 description=Description
 help=Help
 helpUri=More Info
+tags=Tags
 comment=Comment
 textBase64=Long text (base64 example)

--- a/src/main/resources/viewtemplate/ViewTemplate.json
+++ b/src/main/resources/viewtemplate/ViewTemplate.json
@@ -63,6 +63,12 @@
 					"key": "customAttributes.helpUri",
 					"templateId": "SIMPLE",
 					"dataType": "string"
+				},
+				{
+					"type": "template",
+					"key": "customAttributes.tags",
+					"templateId": "COLLAPSE",
+					"dataType": "string"
 				}
 			]
 		}


### PR DESCRIPTION
Display SARIF `tags` when viewing findings.

The tags tend to include useful information for security finding reviewers. For example, semgrep puts CVE, CWE, and OWASP identifiers in the tags.

Here's what this change looks like viewing a semgrep produced finding:

![Screenshot From 2025-04-01 16-14-07](https://github.com/user-attachments/assets/80f5e585-0c9a-4426-9cc3-6641616065a4)