### PR TITLE
feat: line number and snippet

### DIFF
--- a/src/main/java/com/fortify/ssc/parser/sarif/CustomVulnAttribute.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/CustomVulnAttribute.java
@@ -40,6 +40,7 @@ public enum CustomVulnAttribute implements com.fortify.plugin.spi.VulnerabilityA
 	help(AttrType.LONG_STRING),
 	helpUri(AttrType.STRING),
 	tags(AttrType.LONG_STRING),
+	snippet(AttrType.LONG_STRING),
     ;
 
     private final AttrType attributeType;

--- a/src/main/java/com/fortify/ssc/parser/sarif/domain/ArtifactContent.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/domain/ArtifactContent.java
@@ -29,10 +29,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 @Getter
-public final class Region {
-	@JsonProperty private Integer endColumn;
-	@JsonProperty private Integer endLine;
-	@JsonProperty private Integer startColumn;
-	@JsonProperty private Integer startLine;
-	@JsonProperty private ArtifactContent snippet;
+public final class ArtifactContent {
+	@JsonProperty private String text;
 }

--- a/src/main/java/com/fortify/ssc/parser/sarif/domain/Region.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/domain/Region.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2020 Micro Focus or one of its affiliates
+ * (c) Copyright 2025 Micro Focus or one of its affiliates
  *
  * Permission is hereby granted, free of charge, to any person obtaining a 
  * copy of this software and associated documentation files (the 
@@ -29,17 +29,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 @Getter
-public final class PhysicalLocation {
-	@JsonProperty private ArtifactLocation artifactLocation;
-	@JsonProperty private Region region;
-	// @JsonProperty private Region contextRegion;
-	// @JsonProperty private Address address;
-
-	public ArtifactLocation resolveArtifactLocation(RunData runData) {
-		if ( artifactLocation!=null ) {
-			Artifact artifact = runData.getArtifactByIndex(artifactLocation.getIndex());
-			if ( artifact!=null ) { return artifact.getLocation(); }
-		}
-		return artifactLocation;
-	}
+public final class Region {
+	@JsonProperty private Integer endColumn;
+	@JsonProperty private Integer endLine;
+	@JsonProperty private Integer startColumn;
+	@JsonProperty private Integer startLine;
 }

--- a/src/main/java/com/fortify/ssc/parser/sarif/domain/Result.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/domain/Result.java
@@ -82,6 +82,15 @@ public final class Result {
 		return value;
 	}
 	
+	public Integer resolveLineNumber() {
+		Integer value = null;
+		Location[] locations = getLocations();
+		if ( locations!=null && locations.length>0 && locations[0].getPhysicalLocation()!=null && locations[0].getPhysicalLocation().getRegion()!=null && locations[0].getPhysicalLocation().getRegion().getStartLine()!=null ) {
+			value = locations[0].getPhysicalLocation().getRegion().getStartLine();
+		}
+		return value;
+	}
+
 	public ReportingDescriptor resolveRule(RunData runData) {
 		if ( this.resolvedRule == null ) {
 			this.resolvedRule = resolveRuleByIndex(runData);

--- a/src/main/java/com/fortify/ssc/parser/sarif/domain/Result.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/domain/Result.java
@@ -90,6 +90,15 @@ public final class Result {
 		}
 		return value;
 	}
+	
+	public String resolveSnippet() {
+		String value = null;
+		Location[] locations = getLocations();
+		if ( locations!=null && locations.length>0 && locations[0].getPhysicalLocation()!=null && locations[0].getPhysicalLocation().getRegion()!=null && locations[0].getPhysicalLocation().getRegion().getSnippet()!=null ) {
+			value = locations[0].getPhysicalLocation().getRegion().getSnippet().getText();
+		}
+		return value;
+	}
 
 	public ReportingDescriptor resolveRule(RunData runData) {
 		if ( this.resolvedRule == null ) {

--- a/src/main/java/com/fortify/ssc/parser/sarif/parser/VulnerabilitiesProducer.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/parser/VulnerabilitiesProducer.java
@@ -109,6 +109,7 @@ public final class VulnerabilitiesProducer {
 			vb.setStringCustomAttributeValue(CustomVulnAttribute.help, getHelp(runData, result));
 			vb.setStringCustomAttributeValue(CustomVulnAttribute.helpUri, getHelpUri(runData, result));
 			vb.setStringCustomAttributeValue(CustomVulnAttribute.tags, getTags(runData, result));
+			vb.setStringCustomAttributeValue(CustomVulnAttribute.snippet, result.resolveSnippet());
     		
     		vb.completeVulnerability();
 		}

--- a/src/main/java/com/fortify/ssc/parser/sarif/parser/VulnerabilitiesProducer.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/parser/VulnerabilitiesProducer.java
@@ -87,7 +87,7 @@ public final class VulnerabilitiesProducer {
 			
 			//vb.setClassName(null);
     		//vb.setFunctionName(functionName);
-    		//vb.setLineNumber(lineNumber);
+    		vb.setLineNumber(result.resolveLineNumber());
     		//vb.setMappedCategory(mappedCategory);
     		//vb.setMinVirtualCallConfidence(minVirtualCallConfidence);
     		//vb.setPackageName(packageName);

--- a/src/main/resources/plugin.xml
+++ b/src/main/resources/plugin.xml
@@ -5,7 +5,7 @@
     <plugin-info>
         <name>SARIF parser plugin</name>
         <version><!--VERSION-->0.0<!--/VERSION--></version>
-        <data-version>3</data-version>
+        <data-version>4</data-version>
         <vendor name="Micro Focus" url="https://www.microfocus.com"/>
         <description>SARIF parser plugin</description>
         <resources>

--- a/src/main/resources/resources/sarif_en.properties
+++ b/src/main/resources/resources/sarif_en.properties
@@ -25,3 +25,4 @@ helpUri=More Info
 tags=Tags
 comment=Comment
 textBase64=Long text (base64 example)
+snippet=Snippet

--- a/src/main/resources/viewtemplate/ViewTemplate.json
+++ b/src/main/resources/viewtemplate/ViewTemplate.json
@@ -14,6 +14,13 @@
 				},
 				{
 					"type": "template",
+					"title": "Snippet",
+					"key": "customAttributes.snippet",
+					"templateId": "COLLAPSE",
+					"dataType": "string"
+				},
+				{
+					"type": "template",
 					"title": "Category",
 					"key": "customAttributes.categoryAndSubCategory",
 					"templateId": "SIMPLE",


### PR DESCRIPTION
If the SARIF contains [`startLine`](https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790940) information, set that the `lineNumber` for the fortify vulnerability.

When the SARIF includes [snippet](https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790948) information, display that

Here's how it looks with this change when line number and snippet information is available:

![Screenshot From 2025-05-21 10-17-01](https://github.com/user-attachments/assets/103de0ee-1695-4a69-873c-1da5ca76115b)


