### PR TITLE
fix: handle malformed URIs

### DIFF
--- a/src/main/java/com/fortify/ssc/parser/sarif/domain/ArtifactLocation.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/domain/ArtifactLocation.java
@@ -29,13 +29,16 @@ import java.net.URI;
 import java.nio.file.Paths;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import lombok.Getter;
 
 @Getter
 public final class ArtifactLocation implements Serializable {
 	private static final long serialVersionUID = 1L;
-	@JsonProperty private URI uri;
+	@JsonProperty 
+	@JsonDeserialize(using = URIDeserializer.class)
+	private URI uri;
 	@JsonProperty private String uriBaseId;
 	@JsonProperty private Integer index;
 	// @JsonProperty private Message description;

--- a/src/main/java/com/fortify/ssc/parser/sarif/domain/ReportingDescriptor.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/domain/ReportingDescriptor.java
@@ -29,6 +29,7 @@ import java.net.URI;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import lombok.Getter;
 
@@ -48,7 +49,9 @@ public final class ReportingDescriptor implements Serializable {
 	@JsonProperty private Map<String,MultiformatMessageString> messageStrings;
 	@JsonProperty private Message shortDescription;
 	@JsonProperty private Message fullDescription;
-	@JsonProperty private URI helpUri;
+	@JsonProperty 
+	@JsonDeserialize(using = URIDeserializer.class)
+	private URI helpUri;
 	@JsonProperty private MultiformatMessageString help;
 	@JsonProperty private Map<String, Object> properties;
 	

--- a/src/main/java/com/fortify/ssc/parser/sarif/domain/URIDeserializer.java
+++ b/src/main/java/com/fortify/ssc/parser/sarif/domain/URIDeserializer.java
@@ -1,0 +1,68 @@
+package com.fortify.ssc.parser.sarif.domain;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+/**
+ * Custom deserializer for URI fields that handles both proper URIs and file
+ * paths.
+ */
+public class URIDeserializer extends JsonDeserializer<URI> {
+
+    @Override
+    public URI deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        String value = p.getValueAsString();
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+
+        try {
+            return new URI(value);
+        } catch (URISyntaxException e) {
+            return handleAsFilePath(value);
+        }
+    }
+
+    private URI handleAsFilePath(String value) {
+        try {
+            Path path = Paths.get(value);
+            return path.toUri();
+        } catch (Exception e) {
+            return createEncodedURI(value);
+        }
+    }
+
+    /**
+     * Creates a URI by manually encoding special characters.
+     * This is a fallback for cases where the value cannot be parsed as a Path.
+     */
+    private URI createEncodedURI(String value) {
+        try {
+            // Replace spaces and other problematic characters
+            String encoded = value.replace(" ", "%20")
+                    .replace("[", "%5B")
+                    .replace("]", "%5D")
+                    .replace("{", "%7B")
+                    .replace("}", "%7D");
+
+            // Try to create URI with the encoded string
+            return new URI(encoded);
+        } catch (URISyntaxException e) {
+            // Last resort: create a file:// URI with the encoded path
+            try {
+                return new URI("file", null, "/" + value.replace(" ", "%20"), null);
+            } catch (URISyntaxException ex) {
+                // If everything fails, return null or throw
+                // Returning null allows processing to continue
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixing issue of parsing error when encountering malformed URI 
example 
scanning and uploading to ssc [this project ](https://github.com/bnematzadeh/grpc-web-playground) with [opengrep](https://github.com/opengrep/opengrep)  with a SARIF output 
result  in this error : 
```
Exception: An unexpected error occurred during scan processing: com.fortify.manager.exception.FMScanParseException:
Parsing error while parsing scan vulnerabilities: Cannot deserialize value of type 'java.net.URI' from String "2_Server 
Streaming/client/client.js": not a valid textual representation, problem: Illegal character in path at index 8: 2_Server 
Streaming/client/client.js at [Source: (com.fortify.util.io.RegionInputStream); line: 1, column: 3213] (through reference 
chain: com.fortify.ssc.parser.sarif.domain.Result["locations"]->java.lang.Object[][0]-
>com.fortify.ssc.parser.sarif.domain.Location["physicalLocation"]-
>com.fortify.ssc.parser.sarif.domain.PhysicalLocation["artifactLocation"]-
>com.fortify.ssc.parser.sarif.domain.ArtifactLocation["uri"]); session b8mvd7v78ni6a
```
<img width="1543" height="214" alt="image" src="https://github.com/user-attachments/assets/40e65071-bcf9-479f-b067-42264cdaf1f4" />


the SARIF output from opengrep is correct because parsed correctly by other parsers  (eg: VScode [SARIF viewer](https://marketplace.visualstudio.com/items?itemName=MS-SarifVSCode.sarif-viewer) ) 

i have build the the fix and installed on my fortify version and the error is gone.

files causing issue present in this comment https://github.com/fortify/fortify-ssc-parser-sarif/issues/37#issuecomment-3546786238 if you want to reproduce.

Ps : i've fulfilled the form for contributing on this project in [CONTRIBUTING.md](https://github.com/fortify/fortify-ssc-parser-sarif/blob/main/CONTRIBUTING.md)



