### PR TITLE
chore(ci): update release workflows/actions and set read-all workflow permissions with required job-level write overrides

### DIFF
--- a/.github/workflows/build-dev-release.yml
+++ b/.github/workflows/build-dev-release.yml
@@ -1,19 +1,28 @@
-on: 
-  push: 
+on:
+  push:
     branches:
       - '**'
 
 env:
   DIST_DIR: ${{ github.workspace }}/build/dist
+  DO_BUILD: ''
+  DO_RELEASE: ''
+  BRANCH: ''
+  RELEASE_TAG: ''
 
 name: Build development release
+permissions:
+  read-all
+
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Check-out source code
-        uses: actions/checkout@v4
-      
+        uses: actions/checkout@v6
+
       - name: Define development release info
         if: startsWith(github.ref, 'refs/heads/')
         run: |
@@ -22,33 +31,33 @@ jobs:
           echo DO_BUILD=true >> $GITHUB_ENV # We always want to do a build if we're building a branch
           echo BRANCH=${branch} >> $GITHUB_ENV
           echo RELEASE_TAG=${tag} >> $GITHUB_ENV
-          
+
           if git ls-remote --exit-code origin refs/tags/${tag} >/dev/null 2>&1; then
             echo "Found tag ${tag}, development release will be published"
             echo DO_RELEASE=true >> $GITHUB_ENV
-          else 
+          else
             echo "Tag ${tag} does not exist, no development release will be published"
           fi
-          
+
       - name: Build development release
         if: env.DO_BUILD
         run: ./gradlew dist distThirdParty
-        
+
       - name: Publish build artifacts
         if: env.DO_BUILD
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build_artifacts
           path: ${{ env.DIST_DIR }}
-          
+
       - name: Update development release tag
         uses: richardsimko/update-tag@aab2434e9a5040687874aa39d1c6377ec0cb0d94
         if: env.DO_RELEASE
         with:
           tag_name: ${{ env.RELEASE_TAG }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
-        
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create pre-release
         if: env.DO_RELEASE
         run: |
@@ -56,10 +65,4 @@ jobs:
           gh release delete ${{ env.RELEASE_TAG }} -y || true
           gh release create ${{ env.RELEASE_TAG }} -p -t "Development Release - ${{ env.BRANCH }} branch" -n 'See `Assets` section below for latest build artifacts' ${files}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
-          
-      
-          
-      
-
-      
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-prod-release.yml
+++ b/.github/workflows/build-prod-release.yml
@@ -2,25 +2,34 @@ on:
   push:
     branches:
       - main
-      
+
 env:
   DIST_DIR: ${{ github.workspace }}/build/dist
-      
+  DO_RELEASE: ''
+  RELEASE_TAG: ''
+  RELEASE_VERSION: ''
+
 name: Build production release
+permissions:
+  read-all
+
 jobs:
   build-and-release:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Check-out source code
-        uses: actions/checkout@v4
-      
+        uses: actions/checkout@v6
+
       - name: Generate and process release PR
         id: release_please
-        uses: GoogleCloudPlatform/release-please-action@v2
+        uses: googleapis/release-please-action@v4
         with:
           release-type: simple
-          package-name: ${{ github.event.repository.name }}
-          
+
       - name: Define production release info
         if: steps.release_please.outputs.release_created
         run: |
@@ -32,11 +41,11 @@ jobs:
           echo DO_RELEASE=true >> $GITHUB_ENV
           echo RELEASE_TAG=${tag} >> $GITHUB_ENV
           echo RELEASE_VERSION=${version} >> $GITHUB_ENV
-          
+
       - name: Build production release
         if: env.DO_RELEASE
         run: ./gradlew dist distThirdParty -Pversion=${{env.RELEASE_VERSION}}
-      
+
       - name: Upload assets to release
         if: env.DO_RELEASE
         run: |
@@ -45,4 +54,3 @@ jobs:
           gh release upload "${tag}" $files --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          

--- a/.github/workflows/fortify-analysis.yml
+++ b/.github/workflows/fortify-analysis.yml
@@ -8,12 +8,14 @@ on:
     - cron: '16 0 * * 5'
 
 permissions:
-  actions: read
-  contents: read
-  security-events: write
+  read-all
 
 jobs:
   FoD-Scan:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     uses: fortify/.github/.github/workflows/fortify-analysis.yml@main
     with:
       java-version: '17'

--- a/.github/workflows/update-repo-docs.yml
+++ b/.github/workflows/update-repo-docs.yml
@@ -7,7 +7,13 @@ on:
   push:
     branches:
       - main
-      
+
+permissions:
+  read-all
+
 jobs:
   update-repo-docs:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: fortify/shared-doc-resources/.github/workflows/update-repo-docs.yml@main


### PR DESCRIPTION
This PR modernises and hardens GitHub Actions workflows by upgrading key actions, migrating `release-please` usage, and standardising permissions with least-privilege defaults.

